### PR TITLE
Replace abstract classes by interfaces with default implementation

### DIFF
--- a/src/MediatR.Extensions.Cqs/ICancellableCommandHandler.cs
+++ b/src/MediatR.Extensions.Cqs/ICancellableCommandHandler.cs
@@ -1,12 +1,19 @@
 ﻿namespace MediatR.Extensions.Cqs;
 
 /// <summary>
-/// Defines a handler for a command, providing also a <see cref="CancellationToken"></see> to allow cancelling current handling process.
+/// Defines a handler for a command that can be cancelled by caller.
 /// </summary>
 /// <typeparam name="TCommand">The type of command being handled</typeparam>
 public interface ICancellableCommandHandler<in TCommand> : IRequestHandler<TCommand, Unit>
     where TCommand : IRequest<Unit>
 {
+    /// <summary>
+    /// Handle a query.
+    /// Provides a <see cref="CancellationToken"></see> to allow cancelling current handling process.
+    /// </summary>
+    /// <param name="command">Command</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Response</returns>
     public new Task Handle(TCommand command, CancellationToken cancellationToken);
 
     async Task<Unit> IRequestHandler<TCommand, Unit>.Handle(TCommand request, CancellationToken cancellationToken)
@@ -18,13 +25,20 @@ public interface ICancellableCommandHandler<in TCommand> : IRequestHandler<TComm
 }
 
 /// <summary>
-/// Defines a handler for a command, providing also a <see cref="CancellationToken"></see> to allow cancelling current handling process.
+/// Defines a handler for a command that can be cancelled by caller.
 /// </summary>
 /// <typeparam name="TCommand">The type of command being handled</typeparam>
 /// <typeparam name="TResponse">The type of response from the handler</typeparam>
 public interface ICancellableCommandHandler<in TCommand, TResponse> : IRequestHandler<TCommand, TResponse>
     where TCommand : IRequest<TResponse>
 {
+    /// <summary>
+    /// Handle a query.
+    /// Provides a <see cref="CancellationToken"></see> to allow cancelling current handling process.
+    /// </summary>
+    /// <param name="command">Command</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Response</returns>
     public new Task<TResponse> Handle(TCommand command, CancellationToken cancellationToken);
 
     Task<TResponse> IRequestHandler<TCommand, TResponse>.Handle(TCommand command, CancellationToken cancellationToken)

--- a/src/MediatR.Extensions.Cqs/ICancellableCommandHandler.cs
+++ b/src/MediatR.Extensions.Cqs/ICancellableCommandHandler.cs
@@ -1,0 +1,32 @@
+﻿namespace MediatR.Extensions.Cqs;
+
+/// <summary>
+/// Defines a handler for a command, providing also a <see cref="CancellationToken"></see> to allow cancelling current handling process.
+/// </summary>
+/// <typeparam name="TCommand">The type of command being handled</typeparam>
+public interface ICancellableCommandHandler<in TCommand> : IRequestHandler<TCommand, Unit>
+    where TCommand : IRequest<Unit>
+{
+    public new Task Handle(TCommand command, CancellationToken cancellationToken);
+
+    async Task<Unit> IRequestHandler<TCommand, Unit>.Handle(TCommand request, CancellationToken cancellationToken)
+    {
+        await Handle(request, cancellationToken);
+
+        return Unit.Value;
+    }
+}
+
+/// <summary>
+/// Defines a handler for a command, providing also a <see cref="CancellationToken"></see> to allow cancelling current handling process.
+/// </summary>
+/// <typeparam name="TCommand">The type of command being handled</typeparam>
+/// <typeparam name="TResponse">The type of response from the handler</typeparam>
+public interface ICancellableCommandHandler<in TCommand, TResponse> : IRequestHandler<TCommand, TResponse>
+    where TCommand : IRequest<TResponse>
+{
+    public new Task<TResponse> Handle(TCommand command, CancellationToken cancellationToken);
+
+    Task<TResponse> IRequestHandler<TCommand, TResponse>.Handle(TCommand command, CancellationToken cancellationToken)
+        => Handle(command, cancellationToken);
+}

--- a/src/MediatR.Extensions.Cqs/ICancellableQueryHandler.cs
+++ b/src/MediatR.Extensions.Cqs/ICancellableQueryHandler.cs
@@ -1,0 +1,21 @@
+﻿namespace MediatR.Extensions.Cqs;
+
+/// <summary>
+/// Defines a handler for a query that can be cancelled by caller.
+/// </summary>
+/// <typeparam name="TQuery">The type of query being handled</typeparam>
+/// <typeparam name="TResponse">The type of response from the handler</typeparam>
+public interface ICancellableQueryHandler<in TQuery, TResponse> : IRequestHandler<TQuery, TResponse>
+    where TQuery : IQuery<TResponse>
+{
+    /// <summary>
+    /// Handle a query.
+    /// </summary>
+    /// <param name="query">Query</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Response</returns>
+    public new Task<TResponse> Handle(TQuery query, CancellationToken cancellationToken);
+
+    Task<TResponse> IRequestHandler<TQuery, TResponse>.Handle(TQuery query, CancellationToken cancellationToken)
+        => Handle(query, cancellationToken);
+}

--- a/src/MediatR.Extensions.Cqs/ICancellableQueryHandler.cs
+++ b/src/MediatR.Extensions.Cqs/ICancellableQueryHandler.cs
@@ -10,6 +10,7 @@ public interface ICancellableQueryHandler<in TQuery, TResponse> : IRequestHandle
 {
     /// <summary>
     /// Handle a query.
+    /// Provides a <see cref="CancellationToken"></see> to allow cancelling current handling process.
     /// </summary>
     /// <param name="query">Query</param>
     /// <param name="cancellationToken">Cancellation token</param>

--- a/src/MediatR.Extensions.Cqs/ICommand.cs
+++ b/src/MediatR.Extensions.Cqs/ICommand.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Marker interface to represent a command with a void response
 /// </summary>
-public interface ICommand : IRequest<Unit> { }
+public interface ICommand : IRequest<Unit>, IBaseCommand { }
 
 /// <summary>
 /// Marker interface to represent a command with a response

--- a/src/MediatR.Extensions.Cqs/ICommandHandler.cs
+++ b/src/MediatR.Extensions.Cqs/ICommandHandler.cs
@@ -15,7 +15,7 @@ public interface ICommandHandler<in TCommand, TResponse> : IRequestHandler<TComm
     /// <returns>Response from the command</returns>
     Task<TResponse> Handle(TCommand command);
 
-    Task<TResponse> IRequestHandler<TCommand, TResponse>.Handle(TCommand request, CancellationToken _) 
+    Task<TResponse> IRequestHandler<TCommand, TResponse>.Handle(TCommand request, CancellationToken _)
         => Handle(request);
 }
 
@@ -41,3 +41,4 @@ public interface ICommandHandler<in TCommand> : IRequestHandler<TCommand, Unit>
         return Unit.Value;
     }
 }
+

--- a/src/MediatR.Extensions.Cqs/ICommandHandler.cs
+++ b/src/MediatR.Extensions.Cqs/ICommandHandler.cs
@@ -14,9 +14,8 @@ public interface ICommandHandler<in TCommand, TResponse> : IRequestHandler<TComm
     /// <param name="command">The command</param>
     /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Response from the command</returns>
-    Task<TResponse> Handle(TCommand command, CancellationToken cancellationToken);
+    new Task<TResponse> Handle(TCommand command, CancellationToken cancellationToken);
 }
-
 
 /// <summary>
 /// Defines a handler for a command with a void (<see cref="Unit" />) response.
@@ -26,61 +25,18 @@ public interface ICommandHandler<in TCommand, TResponse> : IRequestHandler<TComm
 public interface ICommandHandler<in TCommand> : IRequestHandler<TCommand, Unit>
     where TCommand : IRequest<Unit>
 {
-}
+    /// <summary>
+    /// Handles a command
+    /// </summary>
+    /// <param name="command">The command</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Response from the command</returns>
+    new Task Handle(TCommand command, CancellationToken cancellationToken);
 
-/// <summary>
-/// Wrapper class for a handler that asynchronously handles a command and does not return a response
-/// </summary>
-/// <typeparam name="TCommand">The type of command being handled</typeparam>
-public abstract class AsyncCommandHandler<TCommand> : IRequestHandler<TCommand>
-    where TCommand : ICommand
-{
-    async Task<Unit> IRequestHandler<TCommand, Unit>.Handle(TCommand command, CancellationToken cancellationToken)
+    async Task<Unit> IRequestHandler<TCommand, Unit>.Handle(TCommand request, CancellationToken cancellationToken)
     {
-        await Handle(command, cancellationToken).ConfigureAwait(false);
+        await Handle(request, cancellationToken);
+
         return Unit.Value;
     }
-
-    /// <summary>
-    /// Override in a derived class for the handler logic
-    /// </summary>
-    /// <param name="command">Command</param>
-    /// <param name="cancellationToken"></param>
-    /// <returns>Response</returns>
-    protected abstract Task Handle(TCommand command, CancellationToken cancellationToken);
-}
-
-/// <summary>
-/// Wrapper class for a handler that synchronously handles a command and returns a response
-/// </summary>
-/// <typeparam name="TCommand">The type of command being handled</typeparam>
-/// <typeparam name="TResponse">The type of response from the handler</typeparam>
-public abstract class CommandHandler<TCommand, TResponse> : IRequestHandler<TCommand, TResponse>
-    where TCommand : ICommand<TResponse>
-{
-    Task<TResponse> IRequestHandler<TCommand, TResponse>.Handle(TCommand command, CancellationToken cancellationToken)
-        => Task.FromResult(Handle(command));
-
-    /// <summary>
-    /// Override in a derived class for the handler logic
-    /// </summary>
-    /// <param name="command">Command</param>
-    /// <returns>Response</returns>
-    protected abstract TResponse Handle(TCommand command);
-}
-
-/// <summary>
-/// Wrapper class for a handler that synchronously handles a command and does not return a response
-/// </summary>
-/// <typeparam name="TCommand">The type of command being handled</typeparam>
-public abstract class CommandHandler<TCommand> : IRequestHandler<TCommand>
-    where TCommand : ICommand<Unit>
-{
-    Task<Unit> IRequestHandler<TCommand, Unit>.Handle(TCommand command, CancellationToken cancellationToken)
-    {
-        Handle(command);
-        return Unit.Task;
-    }
-
-    protected abstract void Handle(TCommand command);
 }

--- a/src/MediatR.Extensions.Cqs/ICommandHandler.cs
+++ b/src/MediatR.Extensions.Cqs/ICommandHandler.cs
@@ -12,9 +12,11 @@ public interface ICommandHandler<in TCommand, TResponse> : IRequestHandler<TComm
     /// Handles a command
     /// </summary>
     /// <param name="command">The command</param>
-    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Response from the command</returns>
-    new Task<TResponse> Handle(TCommand command, CancellationToken cancellationToken);
+    Task<TResponse> Handle(TCommand command);
+
+    Task<TResponse> IRequestHandler<TCommand, TResponse>.Handle(TCommand request, CancellationToken _) 
+        => Handle(request);
 }
 
 /// <summary>
@@ -29,13 +31,12 @@ public interface ICommandHandler<in TCommand> : IRequestHandler<TCommand, Unit>
     /// Handles a command
     /// </summary>
     /// <param name="command">The command</param>
-    /// <param name="cancellationToken">Cancellation token</param>
     /// <returns>Response from the command</returns>
-    new Task Handle(TCommand command, CancellationToken cancellationToken);
+    Task Handle(TCommand command);
 
-    async Task<Unit> IRequestHandler<TCommand, Unit>.Handle(TCommand request, CancellationToken cancellationToken)
+    async Task<Unit> IRequestHandler<TCommand, Unit>.Handle(TCommand request, CancellationToken _)
     {
-        await Handle(request, cancellationToken);
+        await Handle(request);
 
         return Unit.Value;
     }

--- a/src/MediatR.Extensions.Cqs/IQueryHandler.cs
+++ b/src/MediatR.Extensions.Cqs/IQueryHandler.cs
@@ -1,7 +1,7 @@
 ﻿namespace MediatR.Extensions.Cqs;
 
 /// <summary>
-/// Wrapper class for a handler that synchronously handles a query and returns a response
+/// Defines a handler for a query
 /// </summary>
 /// <typeparam name="TQuery">The type of query being handled</typeparam>
 /// <typeparam name="TResponse">The type of response from the handler</typeparam>
@@ -15,6 +15,6 @@ public interface IQueryHandler<in TQuery, TResponse> : IRequestHandler<TQuery, T
     /// <returns>Response</returns>
     public Task<TResponse> Handle(TQuery query);
 
-    Task<TResponse> IRequestHandler<TQuery, TResponse>.Handle(TQuery query, CancellationToken cancellationToken)
+    Task<TResponse> IRequestHandler<TQuery, TResponse>.Handle(TQuery query, CancellationToken _)
         => Handle(query);
 }

--- a/src/MediatR.Extensions.Cqs/IQueryHandler.cs
+++ b/src/MediatR.Extensions.Cqs/IQueryHandler.cs
@@ -1,86 +1,20 @@
 ﻿namespace MediatR.Extensions.Cqs;
 
 /// <summary>
-/// Defines a handler for a query
-/// </summary>
-/// <typeparam name="TQuery">The type of query being handled</typeparam>
-/// <typeparam name="TResponse">The type of response from the handler</typeparam>
-public interface IQueryHandler<in TQuery, TResponse> : IRequestHandler<TQuery, TResponse>
-    where TQuery : IRequest<TResponse>
-{
-    /// <summary>
-    /// Handles a query
-    /// </summary>
-    /// <param name="query">The query</param>
-    /// <param name="cancellationToken">Cancellation token</param>
-    /// <returns>Response from the query</returns>
-    Task<TResponse> Handle(TQuery query, CancellationToken cancellationToken);
-}
-
-
-/// <summary>
-/// Defines a handler for a query with a void (<see cref="Unit" />) response.
-/// You do not need to register this interface explicitly with a container as it inherits from the base <see cref="IQueryHandler{TQuery, TResponse}" /> interface.
-/// </summary>
-/// <typeparam name="TQuery">The type of query being handled</typeparam>
-public interface IQueryHandler<in TQuery> : IRequestHandler<TQuery, Unit>
-    where TQuery : IRequest<Unit>
-{
-}
-
-/// <summary>
-/// Wrapper class for a handler that asynchronously handles a query and does not return a response
-/// </summary>
-/// <typeparam name="TQuery">The type of query being handled</typeparam>
-public abstract class AsyncQueryHandler<TQuery> : IRequestHandler<TQuery>
-    where TQuery : IQuery
-{
-    async Task<Unit> IRequestHandler<TQuery, Unit>.Handle(TQuery query, CancellationToken cancellationToken)
-    {
-        await Handle(query, cancellationToken).ConfigureAwait(false);
-        return Unit.Value;
-    }
-
-    /// <summary>
-    /// Override in a derived class for the handler logic
-    /// </summary>
-    /// <param name="query">Query</param>
-    /// <param name="cancellationToken"></param>
-    /// <returns>Response</returns>
-    protected abstract Task Handle(TQuery query, CancellationToken cancellationToken);
-}
-
-/// <summary>
 /// Wrapper class for a handler that synchronously handles a query and returns a response
 /// </summary>
 /// <typeparam name="TQuery">The type of query being handled</typeparam>
 /// <typeparam name="TResponse">The type of response from the handler</typeparam>
-public abstract class QueryHandler<TQuery, TResponse> : IRequestHandler<TQuery, TResponse>
+public interface IQueryHandler<in TQuery, TResponse> : IRequestHandler<TQuery, TResponse>
     where TQuery : IQuery<TResponse>
 {
-    Task<TResponse> IRequestHandler<TQuery, TResponse>.Handle(TQuery query, CancellationToken cancellationToken)
-        => Task.FromResult(Handle(query));
-
     /// <summary>
-    /// Override in a derived class for the handler logic
+    /// Handle a query.
     /// </summary>
     /// <param name="query">Query</param>
     /// <returns>Response</returns>
-    protected abstract TResponse Handle(TQuery query);
-}
+    public Task<TResponse> Handle(TQuery query);
 
-/// <summary>
-/// Wrapper class for a handler that synchronously handles a query does not return a response
-/// </summary>
-/// <typeparam name="TQuery">The type of query being handled</typeparam>
-public abstract class QueryHandler<TQuery> : IRequestHandler<TQuery>
-    where TQuery : IQuery
-{
-    Task<Unit> IRequestHandler<TQuery, Unit>.Handle(TQuery query, CancellationToken cancellationToken)
-    {
-        Handle(query);
-        return Unit.Task;
-    }
-
-    protected abstract void Handle(TQuery query);
+    Task<TResponse> IRequestHandler<TQuery, TResponse>.Handle(TQuery query, CancellationToken cancellationToken)
+        => Handle(query);
 }

--- a/src/MediatR.Extensions.Cqs/SynchronousCommandHandler.cs
+++ b/src/MediatR.Extensions.Cqs/SynchronousCommandHandler.cs
@@ -1,0 +1,37 @@
+﻿namespace MediatR.Extensions.Cqs;
+
+/// <summary>
+/// Wrapper class for a handler that synchronously handles a command and returns a response
+/// </summary>
+/// <typeparam name="TCommand">The type of command being handled</typeparam>
+/// <typeparam name="TResponse">The type of response from the handler</typeparam>
+public abstract class SynchronousCommandHandler<TCommand, TResponse> : ICommandHandler<TCommand, TResponse>
+    where TCommand : ICommand<TResponse>
+{
+    Task<TResponse> ICommandHandler<TCommand, TResponse>.Handle(TCommand command)
+        => Task.FromResult(Handle(command));
+
+    /// <summary>
+    /// Override in a derived class for the handler logic
+    /// Handles a command
+    /// </summary>
+    /// <param name="command">Command</param>
+    /// <returns>Response</returns>
+    protected abstract TResponse Handle(TCommand command);
+}
+
+/// <summary>
+/// Wrapper class for a handler that synchronously handles a command and does not return a response
+/// </summary>
+/// <typeparam name="TCommand">The type of command being handled</typeparam>
+public abstract class SynchronousCommandHandler<TCommand> : ICommandHandler<TCommand>
+    where TCommand : ICommand
+{
+    Task ICommandHandler<TCommand>.Handle(TCommand command)
+    {
+        Handle(command);
+        return Task.CompletedTask;
+    }
+
+    protected abstract void Handle(TCommand command);
+}

--- a/src/MediatR.Extensions.Cqs/SynchronousQueryHandler.cs
+++ b/src/MediatR.Extensions.Cqs/SynchronousQueryHandler.cs
@@ -1,0 +1,19 @@
+﻿namespace MediatR.Extensions.Cqs;
+
+/// <summary>
+/// Wrapper class for a handler that synchronously handles a query and returns a response
+/// </summary>
+/// <typeparam name="TQuery">The type of query being handled</typeparam>
+/// <typeparam name="TResponse">The type of response from the handler</typeparam>
+public abstract class SynchronousQueryHandler<TQuery, TResponse> : IQueryHandler<TQuery, TResponse>
+    where TQuery : IQuery<TResponse>
+{
+    Task<TResponse> IQueryHandler<TQuery, TResponse>.Handle(TQuery query) => Task.FromResult(Handle(query));
+
+    /// <summary>
+    /// Synchronously handle a query.
+    /// </summary>
+    /// <param name="query">Query</param>
+    /// <returns>Response</returns>
+    protected abstract TResponse Handle(TQuery query);
+}

--- a/test/MediatR.Extensions.Cqs.Tests/CommandHandlerTests.cs
+++ b/test/MediatR.Extensions.Cqs.Tests/CommandHandlerTests.cs
@@ -1,6 +1,5 @@
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
 using Shouldly;
 using Xunit;
 
@@ -45,6 +44,6 @@ public record PingVoidCommand(string Message) : ICommand;
 
 public class PingVoidCommandHandler : ICommandHandler<PingVoidCommand>
 {
-    public Task<Unit> Handle(PingVoidCommand request, CancellationToken cancellationToken)
-        => Task.FromResult(Unit.Value);
+    public Task Handle(PingVoidCommand request, CancellationToken cancellationToken)
+        => Task.Delay(0, cancellationToken);
 }

--- a/test/MediatR.Extensions.Cqs.Tests/CommandHandlerTests.cs
+++ b/test/MediatR.Extensions.Cqs.Tests/CommandHandlerTests.cs
@@ -44,6 +44,22 @@ public class CommandHandlerTests : TestBase
         await SendCommandAndThenCancel(new LongPingVoidCommand("Ping"));
     }
 
+    [Fact]
+    public async Task Command_is_processed_by_synchronous_handler()
+    {
+        var result = await _mediator.Send(new RunCommandLine());
+
+        result.ShouldBeAssignableTo<Unit>();
+    }
+
+    [Fact]
+    public async Task Command_with_result_is_processed_by_synchronous_handler()
+    {
+        var result = await _mediator.Send(new RunCommandLineWithOutput());
+
+        result.ShouldBeAssignableTo<Output>();
+    }
+
     private async Task SendCommandAndThenCancel(IBaseCommand command)
     {
         using var tokenSource = new CancellationTokenSource();
@@ -93,4 +109,20 @@ public class LongPingVoidCommandHandler : ICancellableCommandHandler<LongPingVoi
     {
         await Task.Delay(100, cancellationToken);
     }
+}
+
+public record RunCommandLine : ICommand;
+
+public class RunCommandLineHandler : SynchronousCommandHandler<RunCommandLine>
+{
+    protected override void Handle(RunCommandLine command)
+    {
+        // doing stuff
+    }
+}
+public record RunCommandLineWithOutput : ICommand<Output>;
+public record Output;
+public class RunCommandLineWithOutputHandler : SynchronousCommandHandler<RunCommandLineWithOutput, Output>
+{
+    protected override Output Handle(RunCommandLineWithOutput command) => new();
 }

--- a/test/MediatR.Extensions.Cqs.Tests/CommandHandlerTests.cs
+++ b/test/MediatR.Extensions.Cqs.Tests/CommandHandlerTests.cs
@@ -50,13 +50,11 @@ public class CommandHandlerTests : TestBase
 
         var task = _mediator.Send(command, tokenSource.Token);
 
-        await Task.Delay(50, tokenSource.Token);
-
         tokenSource.Cancel();
 
         Func<Task> waitingTask = async () => await task;
 
-        waitingTask.ShouldThrow<TaskCanceledException>();
+        await waitingTask.ShouldThrowAsync<TaskCanceledException>();
     }
 }
 
@@ -82,11 +80,8 @@ public class LongPingCommandHandler : ICancellableCommandHandler<LongPingCommand
 {
     public async Task<Pong> Handle(LongPingCommand command, CancellationToken cancellationToken)
     {
-        for (int i = 0; i < 10; i++)
-        {
-            await Task.Delay(50, cancellationToken);
-        }
-
+        await Task.Delay(100, cancellationToken);
+        
         return new Pong($"{command.Message} Pong");
     }
 }
@@ -96,9 +91,6 @@ public class LongPingVoidCommandHandler : ICancellableCommandHandler<LongPingVoi
 {
     public async Task Handle(LongPingVoidCommand command, CancellationToken cancellationToken)
     {
-        for (int i = 0; i < 10; i++)
-        {
-            await Task.Delay(50, cancellationToken);
-        }
+        await Task.Delay(100, cancellationToken);
     }
 }

--- a/test/MediatR.Extensions.Cqs.Tests/QueryHandlerTests.cs
+++ b/test/MediatR.Extensions.Cqs.Tests/QueryHandlerTests.cs
@@ -25,7 +25,7 @@ public class QueryHandlerTests : TestBase
     }
     
     [Fact]
-    public async Task Synchronous_query_handler_is_correctly_called_by_mediator()
+    public async Task Query_is_processed_by_synchronous_handler()
     {
         var result = await _mediator.Send(new GetUserDetails());
 
@@ -48,7 +48,6 @@ public class QueryHandlerTests : TestBase
     }
 
     public record PingQuery(string Message) : IQuery<Pong>;
-
     public class PingQueryHandler : IQueryHandler<PingQuery, Pong>
     {
         public Task<Pong> Handle(PingQuery query)
@@ -56,18 +55,14 @@ public class QueryHandlerTests : TestBase
     }
 
     public record GetUserDetails : IQuery<UserDetails>;
-
     private record UserDetails;
-
     private class GetUserDetailsHandler : SynchronousQueryHandler<GetUserDetails, UserDetails>
     {
         protected override UserDetails Handle(GetUserDetails query) => new();
     }
 
     public record GetHugeData : IQuery<HugeData>;
-
     private record HugeData;
-
     private class GetHugeDataHandler : ICancellableQueryHandler<GetHugeData, HugeData>
     {
         public async Task<HugeData> Handle(GetHugeData query, CancellationToken cancellationToken)

--- a/test/MediatR.Extensions.Cqs.Tests/QueryHandlerTests.cs
+++ b/test/MediatR.Extensions.Cqs.Tests/QueryHandlerTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.DependencyInjection;
+﻿using System.Threading.Tasks;
 using Shouldly;
 using Xunit;
 
@@ -25,26 +23,29 @@ public class QueryHandlerTests : TestBase
     }
     
     [Fact]
-    public async Task Query_WithNoResult_ShouldBeConnectedToQueryHandler()
+    public async Task Synchronous_query_handler_is_correctly_called_by_mediator()
     {
-        var result = await _mediator.Send(new PingVoidQuery("Ping"));
+        var result = await _mediator.Send(new GetUserDetails());
 
-        result.ShouldBeAssignableTo<Unit>();
+        result.ShouldNotBeNull();
+        result.ShouldBeAssignableTo<UserDetails>();
     }
     
     public record PingQuery(string Message) : IQuery<Pong>;
 
     public class PingQueryHandler : IQueryHandler<PingQuery, Pong>
     {
-        public Task<Pong> Handle(PingQuery query, CancellationToken cancellationToken)
+        public Task<Pong> Handle(PingQuery query)
             => Task.FromResult(new Pong($"{query.Message} Pong"));
     }
 
-    public record PingVoidQuery(string Message) : IQuery;
+    public record GetUserDetails : IQuery<UserDetails>;
 
-    public class PingVoidQueryHandler : IQueryHandler<PingVoidQuery>
+    private record UserDetails;
+
+    private class GetUserDetailsHandler : SynchronousQueryHandler<GetUserDetails, UserDetails>
     {
-        public Task<Unit> Handle(PingVoidQuery query, CancellationToken cancellationToken)
-            => Task.FromResult(Unit.Value);
+        protected override UserDetails Handle(GetUserDetails query) => new();
     }
 }
+


### PR DESCRIPTION
# Introduction
First I am very glad your repository exists because I was bootstraping the same ! I really like MediatR but the `IRequest` and `INotification` are too abstract when dealing with Domain code. I like the idea of abstracting it.

I really hope your are open to contribution 🙇‍♂️ 

# Updates I propose :
- Since C#8, we can use **default implementation on interfaces**. This is very interesting for composition but also for abstracting interfaces we inherits. I used for 2 years `CommandHandler<>` and `QueryHandler<>` abstract classes in pro project, and single inheritance is a real limitation.

- Most of the time (99%), we don't use `CancellationToken` in the Handler() methods. It is because the process we want to achieve is very often straight forward : retrieving data for DB, updating aggregates, ... The process takes < 50ms to end. I propose so to remove `CancellationToken` from `ICommandHandler` & `IQueryHandler` and to introduce `ICancellableCommandHandler` & `ICancellableQueryHandler` in the rare case we need it.

- Finally, I removed the `.ConfigureAwait(false)` because it is not something that is a standard. It is only useful for rich client (WPF or so) that requires the process to end up in the same thread as the original calling thread (UI one). Was it your usecase ? I can re-add it if you like but `AsyncCommandHandler` leds to confusion : aren't Tasks already asynchronous ?